### PR TITLE
Added module for inserting media into posts

### DIFF
--- a/_includes/image
+++ b/_includes/image
@@ -1,0 +1,9 @@
+{% capture imagePath %}{{ page.date | date: "%Y-%m-%d" }}-{{ page.title | slugify }}/{{ include.name }}{% endcapture %}
+{% if include.caption %}
+<figure>
+    <img src="{{site.url}}/assets/img/posts/{{ imagePath }}" {% if include.alt %} alt="{{ include.alt }}" {% endif %} {% if include.width %} width="{{ include.width }}" {% endif %}/>
+    <figcaption>{{ include.caption }}</figcaption>
+</figure>
+{% else %}
+<img src="{{site.url}}/assets/img/posts/{{ imagePath }}" {% if include.alt %} alt="{{ include.alt }}" {% endif %} {% if include.width %} width="{{ include.width }}" {% endif %}/>
+{% endif %}


### PR DESCRIPTION
Used the method described in [this post](https://eduardoboucas.com/blog/2014/12/07/including-and-managing-images-in-jekyll.html) to make it easier for media to be organized and inserted into posts.